### PR TITLE
Add support for linux-gcc-aarch64.

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,6 +20,9 @@ jobs:
           - os: ubuntu-22.04
             platform: linux-gcc CXX=g++-12
           - os: ubuntu-22.04
+            platform: linux-gcc
+            container: quay.io/pypa/manylinux_2_28_x86_64
+          - os: ubuntu-22.04
             platform: linux-clang CXX=clang++-13
           - os: ubuntu-22.04
             platform: linux-clang CXX=clang++-14

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -28,6 +28,14 @@ jobs:
             platform: linux-clang CXX=clang++-14
           - os: ubuntu-22.04
             platform: linux-clang CXX=clang++-15
+          - os: ubuntu-22.04-arm
+            platform: linux-gcc CXX=g++-9
+          - os: ubuntu-22.04-arm
+            platform: linux-gcc CXX=g++-10
+          - os: ubuntu-22.04-arm
+            platform: linux-gcc CXX=g++-11
+          - os: ubuntu-22.04-arm
+            platform: linux-gcc CXX=g++-12
           - os: windows-2022
             platform: win-vs-32
           - os: windows-2022

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 Version 2.2.2-dev
 -----------------
-
+- Add support for `linux-gcc-aarch64`.
 
 Version 2.2.1 [17 Oct 2023]
 ---------------------------

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -40,8 +40,8 @@ on the `make` command line) are the following:
   if the `architecture` is missing, the system architecture is used.
 
   The available platforms are:
-  - `linux`, `linux-gcc`, `linux-gcc-64`, `linux-gcc-32`:
-    Linux system using the gcc compiler, targeting x86_64 or x86.
+  - `linux`, `linux-gcc`, `linux-gcc-64`, `linux-gcc-32`, `linux-gcc-aarch64`:
+    Linux system using the gcc compiler, targeting x86_64, x86 or aarch64.
   - `linux-clang`, `linux-clang-64`, `linux-clang-32`:
     Linux system using the clang compiler, targeting x86_64 or x86.
   - `win`, `win-vs`, `win-vs-64`, `win-vs-32`:

--- a/Makefile.builtem
+++ b/Makefile.builtem
@@ -40,6 +40,8 @@ ifneq ($(filter linux-gcc linux-clang,$(PLATFORM)),)
     override PLATFORM:=$(PLATFORM)-64
   else ifneq ($(filter i386 i686,$(PLATFORM_ARCH)),)
     override PLATFORM:=$(PLATFORM)-32
+  else ifneq ($(filter aarch64,$(PLATFORM_ARCH)),)
+    override PLATFORM:=$(PLATFORM)-aarch64
   else
     $(error Architecture $(PLATFORM_ARCH) is currently not supported on platform $(PLATFORM))
   endif
@@ -63,7 +65,7 @@ else ifneq ($(filter macos-clang,$(PLATFORM)),)
 endif
 
 # fail for unknown platforms
-PLATFORMS = linux-gcc-64 linux-gcc-32 linux-clang-64 linux-clang-32
+PLATFORMS = linux-gcc-64 linux-gcc-32 linux-gcc-aarch64 linux-clang-64 linux-clang-32
 PLATFORMS += win-vs-64 win-vs-32 win-gcc-64 win-gcc-32
 PLATFORMS += macos-clang-64 macos-clang-arm64
 ifeq ($(filter $(PLATFORMS),$(PLATFORM)),)
@@ -193,7 +195,8 @@ ifneq ($(filter linux-gcc-% linux-clang-% win-gcc-%,$(PLATFORM)),)
   ifneq ($(filter undefined default,$(origin CXX)),)
     CXX = $(if $(findstring -gcc-,$(PLATFORM)),g++,clang++)
   endif
-  C_FLAGS += -std=$(CPP_STANDARD) -W -Wall -mtune=generic -msse -msse2 -mfpmath=sse -fvisibility=hidden
+  C_FLAGS += -std=$(CPP_STANDARD) -W -Wall -mtune=generic -fvisibility=hidden
+  C_FLAGS += $(if $(filter-out aarch64,$(PLATFORM_ARCH)),-msse -msse2 -mfpmath=sse)
   C_FLAGS += $(if $(filter win-%,$(PLATFORM)),-DWIN32 -DUNICODE -D_UNICODE -D_WIN32_WINNT=0x0601)
   DYN_C_FLAGS += $(if $(filter linux-%,$(PLATFORM)),-fPIC)
   DYN_LD_FLAGS += -shared


### PR DESCRIPTION
> [!WARNING]
> I have never written a Makefile before and have limited knowledge of compiler flags.

The main purpose of this PR is to add support for `linux-gcc-aarch64`.

This patch enables me to run `ufal/udpipe` under Docker on my M1 MacBook.

I also cleaned up CI ~~and copyright headers~~. Take or leave these changes

### Testing

* I have fixed CI and added Arm runners.
  * I have confirmed the [newly added Arm runners failed before the change](https://github.com/david-allison/cpp_builtem/actions/runs/14740838841/job/41378163654)
* Using [`ufal/udpipe`](https://github.com/ufal/udpipe/tree/master) I loaded a custom model and successfully ran:
  * `docker build --no-cache -t udpipe/server .`
  * `docker run --rm -it -p 8080:8080 udpipe/server` 
  * `curl -s -F data=@data.txt -F tokenizer= -F tagger= -F parser= http://127.0.0.1:8080/process | PYTHONIOENCODING=utf-8 python3 -c "import sys,json; sys.stdout.write(json.load(sys.stdin)['result'])"`